### PR TITLE
Feature/fix get sharefiles

### DIFF
--- a/command.py
+++ b/command.py
@@ -7,11 +7,11 @@ import pandas as pd
 from pybacklogpy.BacklogConfigure import BacklogComConfigure
 from pybacklogpy.Issue import Issue, IssueAttachment, IssueComment
 from pybacklogpy.Project import Project
-from pybacklogpy.SharedFile import SharedFile
 from pybacklogpy.User import User
-from pybacklogpy.Wiki import Wiki, WikiAttachment, WikiSharedFile
+from pybacklogpy.Wiki import Wiki, WikiAttachment
 
 from parse import Parse
+from monkey_patch import MySharedFile
 
 SPACE_KEY = str(os.getenv('SPACE_KEY'))
 API_KEY = os.getenv('API_KEY')
@@ -30,11 +30,10 @@ class Command:
         self.issue_attachment_api = IssueAttachment(config)
         self.issue_comment_api = IssueComment(config)
         self.project_api = Project(config)
-        self.sharedfile_api = SharedFile(config)
+        self.sharedfile_api = MySharedFile(config)
         self.user_api = User(config)
         self.wiki_api = Wiki(config)
         self.wiki_attachment_api = WikiAttachment(config)
-        self.wiki_sharedfile_api = WikiSharedFile(config)
 
         parser = argparse.ArgumentParser(description='BacklogのAPIをコマンド化したもの')
 

--- a/command.py
+++ b/command.py
@@ -154,7 +154,7 @@ class Command:
 
         for wiki in wikis:
             for attachment in wiki['attachments']:
-                path = self.wiki_attachment_api.get_wiki_page_attachment(wiki_id=wiki['id'])
+                path = self.wiki_attachment_api.get_wiki_page_attachment(wiki_id=wiki['id'], attachment_id=attachment['id'])
                 logger.info(f"Saved wiki attachment: {path}")
             for shared_file in wiki['sharedFiles']:
                 path = self.sharedfile_api.get_file(project_id_or_key=self.args.project, shared_file_id=shared_file['id'])

--- a/monkey_patch.py
+++ b/monkey_patch.py
@@ -7,7 +7,8 @@ from pybacklogpy.Issue import (Issue, IssueAttachment, IssueComment,
 from pybacklogpy.modules import RequestSender
 from pybacklogpy.Project import Project
 from pybacklogpy.User import User
-from pybacklogpy.Wiki import Wiki, WikiAttachment, WikiSharedFile
+from pybacklogpy.Wiki import Wiki, WikiAttachment
+from pybacklogpy.SharedFile import SharedFile
 
 
 class MyRequestSender(RequestSender):
@@ -43,13 +44,22 @@ class MyRequestSender(RequestSender):
         return f'{self.download_path}{filename}', response
 
 
+class MySharedFile(SharedFile):
+
+    def get_file(self, project_id_or_key, shared_file_id):
+        path = self.base_path + '/{project_id_or_key}/files/{shared_file_id}'\
+            .format(project_id_or_key=project_id_or_key, shared_file_id=shared_file_id)
+
+        return self.rs.get_file(path=path, url_param={})
+
+
 def changed_init(self, config, download_path='./output/'):
     self.old_init(config)
     self.rs = MyRequestSender(config, download_path)
 
 
 def apply_patch():
-    class_list = [Issue, IssueAttachment, IssueComment, IssueSharedFile, Project, User, Wiki, WikiAttachment, WikiSharedFile]
+    class_list = [Issue, IssueAttachment, IssueComment, IssueSharedFile, Project, User, Wiki, WikiAttachment, MySharedFile]
     for backlog_class in class_list:
         old_init = backlog_class.__init__
         backlog_class.__init__ = changed_init


### PR DESCRIPTION
PyBacklogPyのShareFileモジュールでファイル取得ができなかっため、get_fileメソッドにパッチを追加。